### PR TITLE
Implemented separate 'Moderator Event' tab as per Issue #200

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   checks:
 
     runs-on: ubuntu-latest
-    container: eclipse-temurin:17-jdk
+    container: eclipse-temurin:21-jdk
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   release:
 
     runs-on: ubuntu-latest
-    container: eclipse-temurin:17-jdk
+    container: eclipse-temurin:21-jdk
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This application enables faforever.com moderators to perform administrative acti
 - editing runtime translations
 
 # How to use / run it
-- Make sure you have Java 17 or higher installed (JRE or JDK does not matter). Adoptium offers free installation
-  packages [here](https://adoptium.net/?variant=openjdk17) (other Java flavours like Oracle should also work)
+- Make sure you have Java 21 or higher installed (JRE or JDK does not matter). Adoptium offers free installation
+  packages [here](https://adoptium.net/?variant=openjdk21) (other Java flavours like Oracle should also work)
 - Download the right client version for your operating system from the release page
 - Unzip it
 - Go to the bin folder and run the .bat script (Windows) or the .sh script (Linux)

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ mainClassName = 'com.faforever.moderatorclient.Launcher'
 
 group = 'com.faforever'
 description = 'faf-moderator-client'
-sourceCompatibility = '17'
+sourceCompatibility = '21'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ println "Platform is: ${javafxPlatform}"
 dependencies {
     def springBootVersion = "3.1.5"
     def mapStructVersion = "1.5.5.Final"
-    def commonsVersion = "deb598d"
+    def commonsVersion = "6e46109"
 
     annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
     implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))

--- a/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
@@ -212,10 +212,10 @@ public class ModerationReportController implements Controller<Region> {
             String chatLog = header + replayDataParser.getChatMessages().stream()
                     .map(message -> {
                         long timeMillis = message.getTime().toMillis();
-                        String formattedTime = formatTime(timeMillis);
+                        String formattedChatMessageTime = formatChatMessageTime(timeMillis);
 
                         return format("[{0}] from {1} to {2}: {3}",
-                                formattedTime,
+                                formattedChatMessageTime,
                                 message.getSender(), message.getReceiver(), message.getMessage());
                     })
                     .collect(Collectors.joining("\n"));
@@ -238,10 +238,10 @@ public class ModerationReportController implements Controller<Region> {
         String moderatorEventsLog = moderatorEvents.stream()
                 .map(event -> {
                     long timeMillis = event.time().toMillis();
-                    String formattedTime = formatTime(timeMillis);
+                    String formattedChatMessageTime = formatChatMessageTime(timeMillis);
 
                     return format("[{0}] from {1}: {2}",
-                            formattedTime,
+                            formattedChatMessageTime,
                             event.sender(),
                             event.message());
                 })
@@ -250,7 +250,7 @@ public class ModerationReportController implements Controller<Region> {
         moderatorEventTextArea.setText(moderatorEventsLog);
     }
 
-    private String formatTime(long timeMillis) {
+    private String formatChatMessageTime(long timeMillis) {
         if (timeMillis >= 0) {
             return DurationFormatUtils.formatDuration(timeMillis, "HH:mm:ss");
         } else {

--- a/src/main/resources/ui/main_window/report.fxml
+++ b/src/main/resources/ui/main_window/report.fxml
@@ -60,6 +60,9 @@
                         <TextArea fx:id="chatLogTextArea" editable="false" prefHeight="200.0" prefWidth="200.0"/>
                     </content>
                 </Tab>
+                <Tab text="Moderator Event">
+                    <TextArea fx:id="moderatorEventTextArea" editable="false" prefHeight="200.0" prefWidth="200.0"/>
+                </Tab>
             </tabs>
         </TabPane>
     </items>

--- a/src/main/resources/ui/main_window/report.fxml
+++ b/src/main/resources/ui/main_window/report.fxml
@@ -60,7 +60,7 @@
                         <TextArea fx:id="chatLogTextArea" editable="false" prefHeight="200.0" prefWidth="200.0"/>
                     </content>
                 </Tab>
-                <Tab text="Moderator Event">
+                <Tab text="Moderator Events">
                     <TextArea fx:id="moderatorEventTextArea" editable="false" prefHeight="200.0" prefWidth="200.0"/>
                 </Tab>
             </tabs>


### PR DESCRIPTION
This PR addresses Issue #200 by adding a separate 'Moderator Event' tab next to the 'Chat log'.

Changes include:

- Upgrade 'sourceCompatibility' from Java 17 to Java 21
- Upgrade 'commonsVersion' dependency to a new commit from [faf-java-commons](https://github.com/FAForever/faf-java-commons) from commit [deb598d](https://github.com/FAForever/faf-java-commons/commit/deb598df958bbc692911d0a0116f0ec0157368e4) to [6e46109](https://github.com/FAForever/faf-java-commons/commit/6e46109c9b6898cd03d5a73ebc9fce04e163ed0b)
- Added a separate 'Moderator Event' tab next to 'Chat Log'
- Populating the tab 'Moderator Event' with its data
- Update readme for Java 21
- Refactor time formatting method for chat messages

These changes allow moderators to view moderator-specific events entirely separate from the chat log. Currently, it is very basic and more a "proof of concept", but it is a great start to be extended in the future.


Thanks for the detailed issue description @Garanas
Thanks in advance for your code review @Brutus5000 or @Sheikah45

Fixes #200

**Note**: Player name is currently the raw represented focus army. I assume further changes to '[parseModeratorEvent](https://github.com/FAForever/faf-java-commons/commit/6e46109c9b6898cd03d5a73ebc9fce04e163ed0b#diff-13e3f73652978172e56c4056ca3b213ca1ac7313a6b44591c692fc87162e5ac0R280)' at faf-java-commons are needed to reference it to a player name. If the name can already be obtained from the current data, then please correct me.

---

Result in UI:

![image](https://github.com/FAForever/faf-moderator-client/assets/101107758/4c5b4a5a-141d-4f14-9511-04f74d7924bd)


