### PR TITLE
Fix url link for SteamID lookup

### DIFF
--- a/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
@@ -725,7 +725,7 @@ public class ViewHelper {
         steamLookupMenuItem.setOnAction(action -> {
             PlayerFX playerFX = tableView.getSelectionModel().getSelectedItem();
             playerFX.getAccountLinks().stream().filter(accountLink -> accountLink.getServiceType().equals(LinkedServiceType.STEAM)).findFirst().ifPresent(accountLink ->
-                    platformService.showDocument("https://steamidfinder.com/lookup/" + accountLink.getServiceId())
+                    platformService.showDocument("https://steamcommunity.com/profiles/" + accountLink.getServiceId())
             );
         });
 


### PR DESCRIPTION
Fixes #208

Now we can directly go to the steam account again.

Outlined Steps:

- Replaced `https://steamidfinder.com/lookup/` with `https://steamcommunity.com/profiles/`