### PR TITLE
Update method showModeratorEvent to use playerNameFromCommandSource instead of sender

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ println "Platform is: ${javafxPlatform}"
 dependencies {
     def springBootVersion = "3.2.2"
     def mapStructVersion = "1.5.5.Final"
-    def commonsVersion = "6e46109"
+    def commonsVersion = "763f32222acf0011c6b8b36dac9e0462eb433745"
 
     annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
     implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))

--- a/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
@@ -242,7 +242,7 @@ public class ModerationReportController implements Controller<Region> {
 
                     return format("[{0}] from {1}: {2}",
                             formattedChatMessageTime,
-                            event.sender(),
+                            event.playerNameFromCommandSource(),
                             event.message());
                 })
                 .collect(Collectors.joining("\n"));


### PR DESCRIPTION
Improved the moderation workflow by having concise one-liners, instead of detailed event dumps. Additional info will be refactored later.

The output-decision was voted in Zulip by the Moderators, how we should introduce that basic feature.

Preferred:

<details>
  <summary>Screenshot</summary>
  
  ![image](https://github.com/FAForever/faf-moderator-client/assets/101107758/5f5853d0-0e40-485c-8da8-f5843e0316c4)
  
</details>

instead:

<details>
  <summary>Screenshot</summary>

![image](https://github.com/FAForever/faf-moderator-client/assets/101107758/367d1c06-9f73-4254-8c63-329c09e69373)

</details>

---

Outline:

- Changed `sender` to `playerNameFromCommandSource` for method `showModeratorEvent`
- Updated `commonsVersion` for `faf-commons` to make above method available

Info:

`sender` was replaced with `playerNameFromCommandSource` or `playerNameFromArmy` in [that commit](https://github.com/FAForever/faf-java-commons/commit/e904344614290594ba4515d910d15acf4782789f#diff-d72e8e2820311e7f4663587cbd93593f4075d7226c1d0be8bd76c17cc9a5c9e4)

Both represent the player name, I went with `playerNameFromCommandSource`, because it should be more resistant against manipulation.

Fixes #205 