### PR TITLE
Allow mapCount = minMapsAfterVetoes if tokensPerPlayer == 0

### DIFF
--- a/src/main/java/com/faforever/moderatorclient/ui/main_window/LadderMapPoolController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/main_window/LadderMapPoolController.java
@@ -287,7 +287,7 @@ public class LadderMapPoolController implements Controller<SplitPane> {
         int maxTokensPerMap = bracket.getMaxTokensPerMap();
 
         if (maxTokensPerMap == 0) {
-            return mapCount > M;
+            return mapCount > M || (mapCount == M && tokensPerPlayer == 0);
         } else {
             int totalPlayers = teamSize * 2;
             int totalVetoPower = totalPlayers * tokensPerPlayer / maxTokensPerMap;


### PR DESCRIPTION
Allow mapCount = minMapsAfterVetoes if tokensPerPlayer == 0 for dynamic veto tokens per map too (previously was only allowed on static)

These were default DB values so was kinda unfortunate to not be allowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ladder map pool bracket veto validation to correctly allow valid configurations when specific conditions are met, preventing false rejections of valid competitive ladder settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->