### PR TITLE
Show selected avatar via player.currentAvatar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ println "Platform is: ${javafxPlatform}"
 dependencies {
     def springBootVersion = "3.5.6"
     def mapStructVersion = "1.6.3"
-    def commonsVersion = "20251008-e3f795c"
+    def commonsVersion = "20260626-2e8a5a8"
 
     annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
     implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))

--- a/src/main/java/com/faforever/moderatorclient/api/domain/AvatarService.java
+++ b/src/main/java/com/faforever/moderatorclient/api/domain/AvatarService.java
@@ -39,7 +39,8 @@ public class AvatarService {
         List<Avatar> result = fafApi.getAll(Avatar.class, ElideNavigator.of(Avatar.class)
                 .collection()
                 .addInclude("assignments")
-                .addInclude("assignments.player"));
+                .addInclude("assignments.player")
+                .addInclude("assignments.player.currentAvatar"));
         log.trace("found {} avatars", result.size());
         return result;
     }
@@ -50,6 +51,7 @@ public class AvatarService {
                 .collection()
                 .addInclude("assignments")
                 .addInclude("assignments.player")
+                .addInclude("assignments.player.currentAvatar")
                 .setFilter(ElideNavigator.qBuilder().string(attribute).eq(pattern));
 
         List<Avatar> result = fafApi.getAll(Avatar.class, navigator);
@@ -73,6 +75,7 @@ public class AvatarService {
                 .collection()
                 .addInclude("assignments")
                 .addInclude("assignments.player")
+                .addInclude("assignments.player.currentAvatar")
                 .setFilter(ElideNavigator.qBuilder().string(isNumeric ? "assignments.player.id" : "assignments.player.login").eq(pattern));
 
         List<Avatar> result = fafApi.getAll(Avatar.class, navigator);
@@ -115,7 +118,8 @@ public class AvatarService {
         return fafApi.getAll(Avatar.class, ElideNavigator.of(Avatar.class)
                 .collection()
                 .addInclude("assignments")
-                .addInclude("assignments.player"));
+                .addInclude("assignments.player")
+                .addInclude("assignments.player.currentAvatar"));
     }
 
     public void updateAvatarMetadata(String avatarId, String name, String description) {

--- a/src/main/java/com/faforever/moderatorclient/api/domain/UserService.java
+++ b/src/main/java/com/faforever/moderatorclient/api/domain/UserService.java
@@ -58,6 +58,7 @@ public class UserService {
                 .addInclude(variablePrefix + "names")
                 .addInclude(variablePrefix + "avatarAssignments")
                 .addInclude(variablePrefix + "avatarAssignments.avatar")
+                .addInclude(variablePrefix + "currentAvatar")
                 .addInclude(variablePrefix + "uniqueIdAssignments")
                 .addInclude(variablePrefix + "uniqueIdAssignments.uniqueId")
                 .addInclude(variablePrefix + "accountLinks")

--- a/src/main/java/com/faforever/moderatorclient/mapstruct/PlayerMapper.java
+++ b/src/main/java/com/faforever/moderatorclient/mapstruct/PlayerMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapper;
 import java.util.List;
 import java.util.Set;
 
-@Mapper(componentModel = "spring", uses = {JavaFXMapper.class, UniqueIdAssignmentMapper.class, NameRecordMapper.class, BanInfoMapper.class, AvatarAssignmentMapper.class, AccountLinkMapper.class, CycleAvoidingMappingContext.class})
+@Mapper(componentModel = "spring", uses = {JavaFXMapper.class, UniqueIdAssignmentMapper.class, NameRecordMapper.class, BanInfoMapper.class, AvatarAssignmentMapper.class, AvatarMapper.class, AccountLinkMapper.class, CycleAvoidingMappingContext.class})
 public abstract class PlayerMapper {
     public abstract PlayerFX map(Player dto);
 

--- a/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
@@ -42,6 +42,7 @@ import com.faforever.moderatorclient.ui.domain.VotingChoiceFX;
 import com.faforever.moderatorclient.ui.domain.VotingQuestionFX;
 import com.faforever.moderatorclient.ui.domain.VotingSubjectFX;
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -101,6 +102,7 @@ import java.time.format.FormatStyle;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
@@ -228,6 +230,21 @@ public class ViewHelper {
         });
     }
 
+    /**
+     * Whether this assignment's avatar is the player's currently worn avatar, i.e. the one referenced
+     * by {@code login.avatar_id} (exposed as {@link PlayerFX#getCurrentAvatar()}). Replaces the legacy
+     * {@code AvatarAssignment.selected} flag, which the API no longer maintains.
+     */
+    private static boolean isCurrentAvatar(AvatarAssignmentFX avatarAssignment) {
+        if (avatarAssignment == null) {
+            return false;
+        }
+        PlayerFX player = avatarAssignment.getPlayer();
+        AvatarFX avatar = avatarAssignment.getAvatar();
+        return player != null && avatar != null && player.getCurrentAvatar() != null
+                && Objects.equals(player.getCurrentAvatar().getId(), avatar.getId());
+    }
+
     public static void buildAvatarAssignmentTableView(TableView<AvatarAssignmentFX> tableView, ObservableList<AvatarAssignmentFX> data, @Nullable Consumer<AvatarAssignmentFX> onRemove) {
         tableView.setItems(data);
         HashMap<TableColumn<AvatarAssignmentFX, ?>, Function<AvatarAssignmentFX, ?>> extractors = new HashMap<>();
@@ -257,7 +274,7 @@ public class ViewHelper {
         extractors.put(userNameColumn, avatarAssignmentFX -> avatarAssignmentFX.getPlayer().getLogin());
 
         TableColumn<AvatarAssignmentFX, Boolean> selectedColumn = new TableColumn<>("Selected");
-        selectedColumn.setCellValueFactory(o -> o.getValue().selectedProperty());
+        selectedColumn.setCellValueFactory(o -> new SimpleBooleanProperty(isCurrentAvatar(o.getValue())));
         selectedColumn.setMinWidth(50);
         tableView.getColumns().add(selectedColumn);
 
@@ -892,7 +909,7 @@ public class ViewHelper {
         extractors.put(descriptionColumn, avatarAssignmentFX -> avatarAssignmentFX.getAvatar().getDescription());
 
         TableColumn<AvatarAssignmentFX, Boolean> selectedColumn = new TableColumn<>("Selected");
-        selectedColumn.setCellValueFactory(o -> o.getValue().selectedProperty());
+        selectedColumn.setCellValueFactory(o -> new SimpleBooleanProperty(isCurrentAvatar(o.getValue())));
         selectedColumn.setCellFactory(CheckBoxTableCell.forTableColumn(selectedColumn));
         selectedColumn.setMinWidth(50);
         tableView.getColumns().add(selectedColumn);

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/PlayerFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/PlayerFX.java
@@ -25,8 +25,10 @@ public class PlayerFX extends AbstractEntityFX {
     private final ObservableList<NameRecordFX> names;
     private final ObservableList<BanInfoFX> bans;
     private final ObservableList<AvatarAssignmentFX> avatarAssignments;
+    private final ObjectProperty<AvatarFX> currentAvatar;
 
     public PlayerFX() {
+        currentAvatar = new SimpleObjectProperty<>();
         login = new SimpleStringProperty();
         email = new SimpleStringProperty();
         userAgent = new SimpleStringProperty();
@@ -156,6 +158,18 @@ public class PlayerFX extends AbstractEntityFX {
         if (avatarAssignmentFXObservableList != null) {
             avatarAssignments.addAll(avatarAssignmentFXObservableList);
         }
+    }
+
+    public AvatarFX getCurrentAvatar() {
+        return currentAvatar.get();
+    }
+
+    public void setCurrentAvatar(AvatarFX currentAvatar) {
+        this.currentAvatar.set(currentAvatar);
+    }
+
+    public ObjectProperty<AvatarFX> currentAvatarProperty() {
+        return currentAvatar;
     }
 
     public boolean isBannedGlobally() {


### PR DESCRIPTION
## Summary

The moderator client's "Selected" column on avatar-assignment tables read the legacy `AvatarAssignment.selected` flag. The API now tracks a player's worn avatar via `login.avatar_id` — exposed as the `player.currentAvatar` relationship — and no longer maintains `selected`, so every row showed up as **not** selected.

This derives the column from `currentAvatar` instead:

- **`PlayerFX`** — add `currentAvatar` (`ObjectProperty<AvatarFX>`).
- **`PlayerMapper`** — add `AvatarMapper` to `uses` so `currentAvatar` is mapped both directions.
- **`UserService` / `AvatarService`** — include `currentAvatar` (and `assignments.player.currentAvatar`) in the relevant queries.
- **`ViewHelper`** — both "Selected" columns now compute via `isCurrentAvatar(...)`: `player.currentAvatar.id == assignment.avatar.id` (null-safe).
- **`build.gradle`** — bump commons to `20260626-2e8a5a8`, the release that adds `Player.currentAvatar` (FAForever/faf-java-commons#280).

## Context

Part of migrating FAF's "currently selected avatar" off the legacy `avatars.selected` join-table flag to the authoritative `login.avatar_id` FK, with the API as the single writer.

## Verification

`./gradlew clean compileJava` passes against the new commons; the generated `PlayerMapperImpl` wires `currentAvatar` both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar-related views now include each player’s currently selected avatar.
  * Avatar assignment tables show the active avatar more accurately.

* **Bug Fixes**
  * Improved avatar selection indicators in player and user avatar lists.
  * Fixed cases where missing avatar data could cause selection status to display incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->